### PR TITLE
Type fixes

### DIFF
--- a/src/Runtime.d.ts
+++ b/src/Runtime.d.ts
@@ -44,6 +44,14 @@ declare namespace Runtime {
 		stateCounts: Map<Runtime.TopoKey, number>;
 		childCounts: Map<Runtime.TopoKey, number>;
 	};
+
+	type PlasmaRef = symbol & {
+		/**
+		 * @hidden
+		 * @deprecated
+		 */
+		readonly _nominal_PlasmaRef: unique symbol;
+	};
 }
 
 interface Runtime {
@@ -113,7 +121,7 @@ interface Runtime {
  	 * `useInstance` returns the `ref` table that is passed to it. You can use this to create references to objects
 	 * you want to update in the widget body.
 	 */
-	useInstance<T extends object>(this: void, creator: (ref: T) => Instance | LuaTuple<[Instance, GuiObject?]>): T;
+	useInstance<T extends object>(this: void, creator: (ref: Runtime.PlasmaRef) => Instance | LuaTuple<[Instance, GuiObject?]>): T;
 
 	useEffect(this: void, callback: () => (() => void) | void, ...dependencies: ReadonlyArray<unknown>): void;
 

--- a/src/Runtime.d.ts
+++ b/src/Runtime.d.ts
@@ -121,7 +121,10 @@ interface Runtime {
  	 * `useInstance` returns the `ref` table that is passed to it. You can use this to create references to objects
 	 * you want to update in the widget body.
 	 */
-	useInstance<T extends object>(this: void, creator: (ref: Runtime.PlasmaRef) => Instance | LuaTuple<[Instance, GuiObject?]>): T;
+	useInstance<T extends { [index: string]: Instance }>(
+		this: void,
+		creator: (ref: Runtime.PlasmaRef) => Instance | LuaTuple<[Instance, GuiObject?]>,
+	): T;
 
 	useEffect(this: void, callback: () => (() => void) | void, ...dependencies: ReadonlyArray<unknown>): void;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,8 +78,6 @@ interface Plasma extends Plasma.Widgets {
 	useEffect: typeof Runtime.useEffect;
 	useKey: typeof Runtime.useKey;
 	setEventCallback: typeof Runtime.setEventCallback;
-	useContext: typeof Runtime.useContext;
-	createContext: typeof Runtime.createContext;
 
 	useStyle: typeof Style.get;
 	setStyle: typeof Style.set;

--- a/src/widgets/row.d.ts
+++ b/src/widgets/row.d.ts
@@ -1,6 +1,6 @@
 declare namespace row {
 	interface RowOptions {
-		padding?: Vector2;
+		padding?: UDim;
 	}
 }
 


### PR DESCRIPTION
few type issues i've had while messing around with the lib:

- there is no exported `Plasma.createContext` or `Plasma.useContext`, both are located in `Runtime`.
- the `refs` parameter in [`useInstance`](https://eryn.io/plasma/api/Plasma#useInstance)'s callback should be a `symbol` instead of `T` because `ref` is supposed to be used inside `Plasma.create` options, indexing a string that will later become a key in the final `refs` object to reference the instance.

- `padding` property type from `Plasma.row` options should be `UDim` instead of `Vector2`.

![image](https://user-images.githubusercontent.com/46044567/207574545-9385b61f-9d6d-4dfa-80d5-f2143c4a57f1.png)
